### PR TITLE
Resource management

### DIFF
--- a/BPCompatibleAlertController/BPCompatibleAlertController.swift
+++ b/BPCompatibleAlertController/BPCompatibleAlertController.swift
@@ -30,25 +30,25 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
     LoginAndPasswordInpnut = 2
     */
     public var alertViewStyle: UIAlertViewStyle
-	
-	/**
-	If this set, when the user dismisses the alert all the resources used
-	by this alert controller will be automatically released allowing this object to be deallocated.
-	
-	After the user has dismissed the alert, presentFrom: cannot be called again on this object.
-	
-	Should client code set this to false (because they intend to re-user the alert), it must at some stage call releaseResources() to
-	ensure internal resources are freed up.
-	
-	releaseResourcesWhenAlertDismissed defaults to true.
-	*/
-	public var releaseResourcesWhenAlertDismissed: Bool = true
-	
+    
+    /**
+    If this set, when the user dismisses the alert all the resources used
+    by this alert controller will be automatically released allowing this object to be deallocated.
+    
+    After the user has dismissed the alert, presentFrom: cannot be called again on this object.
+    
+    Should client code set this to false (because they intend to re-user the alert), it must at some stage call releaseResources() to
+    ensure internal resources are freed up.
+    
+    releaseResourcesWhenAlertDismissed defaults to true.
+    */
+    public var releaseResourcesWhenAlertDismissed: Bool = true
+    
     private var alertController: UIAlertController!
     private var alertView: UIAlertView!
     private var actions: [String : BPCompatibleAlertAction]
-	private var actionObservers: Array<NSObjectProtocol> = []
-	public var resourcesHaveBeenReleased: Bool = false
+    private var actionObservers: Array<NSObjectProtocol> = []
+    public var resourcesHaveBeenReleased: Bool = false
     private var textFieldConfigurations: [BPCompatibleTextFieldConfigruationHandler]
     private var alertControllerStyle: UIAlertControllerStyle {
         get {
@@ -63,7 +63,7 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
             return objc_getClass("UIAlertController") != nil
         }
     }
-	
+    
     /**
     Creates an instance of BPCompatibleAlertController.
     
@@ -81,7 +81,7 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
         self.actions = [String : BPCompatibleAlertAction]()
         self.textFieldConfigurations = [BPCompatibleTextFieldConfigruationHandler]()
     }
-	
+    
     /**
     Creates a BPCompatibleAlertController with a type of Alert.
     
@@ -117,8 +117,8 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
         // listen to changes on the BPCompatibleAlertAction enabled field to update the UIAlertAction in the alertController
         let observerObject = NSNotificationCenter.defaultCenter().addObserverForName(BPCompatibleAlertActionEnabledDidChangeNotification, object: action, queue: NSOperationQueue.mainQueue()) { (notification) in
             if self.uiAlertControllerAvailable {
-			
-				// This reference to self.alertController has the side effect of preventing ARC from releasing self, which on iOS 7 avoids a crash if the external client code hasn't explicitly retained this alertController.
+            
+                // This reference to self.alertController has the side effect of preventing ARC from releasing self, which on iOS 7 avoids a crash if the external client code hasn't explicitly retained this alertController.
                 for a in self.alertController.actions {
                     if a.title == action.title {
                         if let internalAction = a as? UIAlertAction {
@@ -129,7 +129,7 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
                 }
             }
         }
-		self.actionObservers.append(observerObject)
+        self.actionObservers.append(observerObject)
     }
     
     public func addTextFieldWithConfigurationHandler(configurationHandler : BPCompatibleTextFieldConfigruationHandler ) -> Void {
@@ -145,8 +145,8 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
     :param: completion The completion block to be called when done presenting.
     */
     public func presentFrom(viewController: UIViewController!, animated: Bool, completion: (() -> Void)?) {
-		assert(resourcesHaveBeenReleased == false, "You cannot present an alert controller again after its resources have been released!")
-		
+        assert(resourcesHaveBeenReleased == false, "You cannot present an alert controller again after its resources have been released!")
+        
         if uiAlertControllerAvailable {
             alertController = UIAlertController(title: title, message: message, preferredStyle: alertControllerStyle)
             for action in actions.values {
@@ -155,8 +155,8 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
                     if let handler = action.handler {
                         handler(action)
                     }
-					
-					self.postAlertDismissalActions()
+                    
+                    self.postAlertDismissalActions()
                 })
                 uiAlertAction.enabled = action.enabled
                 alertController.addAction(uiAlertAction)
@@ -235,42 +235,42 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
         if let handler = action.handler {
             handler(action)
         }
-	
-		postAlertDismissalActions()
+    
+        postAlertDismissalActions()
     }
-	
-	/**
-	If the client code has opted to set releaseResourcesWhenAlertDismissed to false, then 
-	this function should be called manually at an appropriate time to free up internal resources
-	and allow this object to be deallocated.
-	*/
-	public func releaseResources()
-	{
-		// Removing observers releases any references to self held by the notification handler block, allowing self to be deallocated
-		stopObservingAlertActionEnabledDidChangeNotification()
-		
-		// Clean up any other objects that may be containining references to self and prevent self from being deallocated
-		actions.removeAll(keepCapacity: false)
-		textFieldConfigurations.removeAll(keepCapacity: false)
-		alertController = nil
-		
-		resourcesHaveBeenReleased = true
-	}
-	
-	private func postAlertDismissalActions()
-	{
-		if (releaseResourcesWhenAlertDismissed)
-		{
-			releaseResources()
-		}
-	}
-	
-	private func stopObservingAlertActionEnabledDidChangeNotification()
-	{
-		for actionObserver in actionObservers
-		{
-			NSNotificationCenter.defaultCenter().removeObserver(actionObserver)
-		}
-		self.actionObservers.removeAll(keepCapacity: false)
-	}
+    
+    /**
+    If the client code has opted to set releaseResourcesWhenAlertDismissed to false, then 
+    this function should be called manually at an appropriate time to free up internal resources
+    and allow this object to be deallocated.
+    */
+    public func releaseResources()
+    {
+        // Removing observers releases any references to self held by the notification handler block, allowing self to be deallocated
+        stopObservingAlertActionEnabledDidChangeNotification()
+        
+        // Clean up any other objects that may be containining references to self and prevent self from being deallocated
+        actions.removeAll(keepCapacity: false)
+        textFieldConfigurations.removeAll(keepCapacity: false)
+        alertController = nil
+        
+        resourcesHaveBeenReleased = true
+    }
+    
+    private func postAlertDismissalActions()
+    {
+        if (releaseResourcesWhenAlertDismissed)
+        {
+            releaseResources()
+        }
+    }
+    
+    private func stopObservingAlertActionEnabledDidChangeNotification()
+    {
+        for actionObserver in actionObservers
+        {
+            NSNotificationCenter.defaultCenter().removeObserver(actionObserver)
+        }
+        self.actionObservers.removeAll(keepCapacity: false)
+    }
 }

--- a/BPCompatibleAlertController/BPCompatibleAlertController.swift
+++ b/BPCompatibleAlertController/BPCompatibleAlertController.swift
@@ -30,10 +30,25 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
     LoginAndPasswordInpnut = 2
     */
     public var alertViewStyle: UIAlertViewStyle
-    
+	
+	/**
+	If this set, when the user dismisses the alert all the resources used
+	by this alert controller will be automatically released allowing this object to be deallocated.
+	
+	After the user has dismissed the alert, presentFrom: cannot be called again on this object.
+	
+	Should client code set this to false (because they intend to re-user the alert), it must at some stage call releaseResources() to
+	ensure internal resources are freed up.
+	
+	releaseResourcesWhenAlertDismissed defaults to true.
+	*/
+	public var releaseResourcesWhenAlertDismissed: Bool = true
+	
     private var alertController: UIAlertController!
     private var alertView: UIAlertView!
     private var actions: [String : BPCompatibleAlertAction]
+	private var actionObservers: Array<NSObjectProtocol> = []
+	public var resourcesHaveBeenReleased: Bool = false
     private var textFieldConfigurations: [BPCompatibleTextFieldConfigruationHandler]
     private var alertControllerStyle: UIAlertControllerStyle {
         get {
@@ -43,12 +58,12 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
         }
     }
     
-    private var isiOS8: Bool {
+    private var uiAlertControllerAvailable: Bool {
         get {
             return objc_getClass("UIAlertController") != nil
         }
     }
-    
+	
     /**
     Creates an instance of BPCompatibleAlertController.
     
@@ -66,7 +81,7 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
         self.actions = [String : BPCompatibleAlertAction]()
         self.textFieldConfigurations = [BPCompatibleTextFieldConfigruationHandler]()
     }
-    
+	
     /**
     Creates a BPCompatibleAlertController with a type of Alert.
     
@@ -100,8 +115,10 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
         actions[action.title!] = action
         
         // listen to changes on the BPCompatibleAlertAction enabled field to update the UIAlertAction in the alertController
-        NSNotificationCenter.defaultCenter().addObserverForName(BPCompatibleAlertActionEnabledDidChangeNotification, object: action, queue: NSOperationQueue.mainQueue()) { (notification) in
-            if self.isiOS8 {
+        let observerObject = NSNotificationCenter.defaultCenter().addObserverForName(BPCompatibleAlertActionEnabledDidChangeNotification, object: action, queue: NSOperationQueue.mainQueue()) { (notification) in
+            if self.uiAlertControllerAvailable {
+			
+				// This reference to self.alertController has the side effect of preventing ARC from releasing self, which on iOS 7 avoids a crash if the external client code hasn't explicitly retained this alertController.
                 for a in self.alertController.actions {
                     if a.title == action.title {
                         if let internalAction = a as? UIAlertAction {
@@ -112,6 +129,7 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
                 }
             }
         }
+		self.actionObservers.append(observerObject)
     }
     
     public func addTextFieldWithConfigurationHandler(configurationHandler : BPCompatibleTextFieldConfigruationHandler ) -> Void {
@@ -127,7 +145,9 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
     :param: completion The completion block to be called when done presenting.
     */
     public func presentFrom(viewController: UIViewController!, animated: Bool, completion: (() -> Void)?) {
-        if isiOS8 {
+		assert(resourcesHaveBeenReleased == false, "You cannot present an alert controller again after its resources have been released!")
+		
+        if uiAlertControllerAvailable {
             alertController = UIAlertController(title: title, message: message, preferredStyle: alertControllerStyle)
             for action in actions.values {
                 
@@ -135,6 +155,8 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
                     if let handler = action.handler {
                         handler(action)
                     }
+					
+					self.postAlertDismissalActions()
                 })
                 uiAlertAction.enabled = action.enabled
                 alertController.addAction(uiAlertAction)
@@ -193,7 +215,7 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
     }
     
     public func textFieldAtIndex(index: Int) -> UITextField? {
-        if isiOS8 {
+        if uiAlertControllerAvailable {
             if alertController.textFields?.count > index {
                 if let textField: UITextField = alertController.textFields![index] as? UITextField {
                     return textField
@@ -213,5 +235,42 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
         if let handler = action.handler {
             handler(action)
         }
+	
+		postAlertDismissalActions()
     }
+	
+	/**
+	If the client code has opted to set releaseResourcesWhenAlertDismissed to false, then 
+	this function should be called manually at an appropriate time to free up internal resources
+	and allow this object to be deallocated.
+	*/
+	public func releaseResources()
+	{
+		// Removing observers releases any references to self held by the notification handler block, allowing self to be deallocated
+		stopObservingAlertActionEnabledDidChangeNotification()
+		
+		// Clean up any other objects that may be containining references to self and prevent self from being deallocated
+		actions.removeAll(keepCapacity: false)
+		textFieldConfigurations.removeAll(keepCapacity: false)
+		alertController = nil
+		
+		resourcesHaveBeenReleased = true
+	}
+	
+	private func postAlertDismissalActions()
+	{
+		if (releaseResourcesWhenAlertDismissed)
+		{
+			releaseResources()
+		}
+	}
+	
+	private func stopObservingAlertActionEnabledDidChangeNotification()
+	{
+		for actionObserver in actionObservers
+		{
+			NSNotificationCenter.defaultCenter().removeObserver(actionObserver)
+		}
+		self.actionObservers.removeAll(keepCapacity: false)
+	}
 }

--- a/BPCompatibleAlertController/BPCompatibleAlertController.swift
+++ b/BPCompatibleAlertController/BPCompatibleAlertController.swift
@@ -67,7 +67,7 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
     private var alertController: UIAlertController!
     private var alertView: BPAlertView!
     private var actions: [String : BPCompatibleAlertAction]
-    private var actionObservers: Array<NSObjectProtocol> = []
+    private var actionObservers: [NSObjectProtocol] = []
     public var resourcesHaveBeenReleased: Bool = false
     private var textFieldConfigurations: [BPCompatibleTextFieldConfigruationHandler]
     private var alertControllerStyle: UIAlertControllerStyle {

--- a/BPCompatibleAlertController/BPCompatibleAlertController.swift
+++ b/BPCompatibleAlertController/BPCompatibleAlertController.swift
@@ -51,6 +51,14 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
     */
     public var alertViewStyle: UIAlertViewStyle
     
+    /** 
+    Client code can optionally set this if they have custom clean up code they want run after an alert action has been triggered.
+    
+    This cleanup function will be run regardless of whether or not the user provided an action handler block with an action.
+    If the user did provide an action handler block, this cleanup function will be invoked after the user supplied handler.
+    */
+    public var postActionHandlerCleanupFunction: ((Void) -> Void)?
+    
     /**
     If this set, when the user dismisses the alert all the resources used
     by this alert controller will be automatically released allowing this object to be deallocated.
@@ -285,15 +293,17 @@ public class BPCompatibleAlertController : NSObject, UIAlertViewDelegate {
     }
     
     private func postAlertDismissalActions() {
-        if (releaseResourcesWhenAlertDismissed)
-        {
+        if (releaseResourcesWhenAlertDismissed) {
             releaseResources()
+        }
+        
+        if (postActionHandlerCleanupFunction != nil) {
+            postActionHandlerCleanupFunction?()
         }
     }
     
     private func stopObservingAlertActionEnabledDidChangeNotification() {
-        for actionObserver in actionObservers
-        {
+        for actionObserver in actionObservers {
             NSNotificationCenter.defaultCenter().removeObserver(actionObserver)
         }
         self.actionObservers.removeAll(keepCapacity: false)

--- a/BPCompatibleAlertControllerDemo/CompatibleAlertControllerDemo/ViewController.swift
+++ b/BPCompatibleAlertControllerDemo/CompatibleAlertControllerDemo/ViewController.swift
@@ -9,52 +9,69 @@
 import UIKit
 
 class ViewController: UIViewController {
-    var alertController: BPCompatibleAlertController?
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+		
+		var observerObject: NSObjectProtocol?
+		
+		let cleanupAfterAlertDismissed: (Void) -> Void =
+			{
+				if (observerObject != nil)
+				{
+					NSNotificationCenter.defaultCenter().removeObserver(observerObject!)
+					observerObject = nil
+				}
+			}
+		
         self.view.backgroundColor = UIColor.whiteColor()
         self.title = "Demo"
         
-        alertController = BPCompatibleAlertController(title: "Alert Title", message: "Alert Message", alertStyle: BPCompatibleAlertControllerStyle.Alert)
-        alertController?.alertViewStyle = UIAlertViewStyle.LoginAndPasswordInput
+        let alertController = BPCompatibleAlertController(title: "Alert Title", message: "Alert Message", alertStyle: BPCompatibleAlertControllerStyle.Alert)
+        alertController.alertViewStyle = UIAlertViewStyle.LoginAndPasswordInput
+		
+		// Set releaseResourcesWhenAlertDismissed to false if you intend to re-use alertController to present the alert multiple times.
+		// If you do so, you must remember to call alertController.releaseResources() when you are finished with the alertController.
+		//alertController.releaseResourcesWhenAlertDismissed = false
         
         let defaultAction = BPCompatibleAlertAction.defaultActionWithTitle("Default", handler: { (action) in
-            if let textField = self.alertController?.textFieldAtIndex(0) {
+            if let textField = alertController.textFieldAtIndex(0) {
                 NSLog("%@", textField.text!)
             }
-            if let textField = self.alertController?.textFieldAtIndex(1) {
+            if let textField = alertController.textFieldAtIndex(1) {
                 NSLog("%@", textField.text!)
             }
+			cleanupAfterAlertDismissed()
         })
         defaultAction.enabled = false
-        alertController?.addAction(defaultAction)
+        alertController.addAction(defaultAction)
         
-        alertController?.addAction(BPCompatibleAlertAction.cancelActionWithTitle("Cancel", handler: { (action) in
+        alertController.addAction(BPCompatibleAlertAction.cancelActionWithTitle("Cancel", handler: { (action) in
             NSLog("Hit cancel")
+			cleanupAfterAlertDismissed()
         }))
         
-        alertController?.addAction(BPCompatibleAlertAction.destructiveActionWithTItle("Destructive", handler: { (action) in
+        alertController.addAction(BPCompatibleAlertAction.destructiveActionWithTItle("Destructive", handler: { (action) in
             NSLog("Hit destroy")
+			cleanupAfterAlertDismissed()
         }))
         
-        alertController?.addTextFieldWithConfigurationHandler({ (textField) in
+        alertController.addTextFieldWithConfigurationHandler({ (textField) in
             textField.placeholder = "Username"
             
             // when the user types in something enable the login
             // when the user types something enable the login
-            NSNotificationCenter.defaultCenter().addObserverForName(UITextFieldTextDidChangeNotification, object: textField, queue: NSOperationQueue.mainQueue()) { (notification) in
+			observerObject = NSNotificationCenter.defaultCenter().addObserverForName(UITextFieldTextDidChangeNotification, object: textField, queue: NSOperationQueue.mainQueue()) { (notification) in
                 defaultAction.enabled = textField.text != ""
             }
         })
         
-        alertController?.addTextFieldWithConfigurationHandler({ (textField) in
+        alertController.addTextFieldWithConfigurationHandler({ (textField) in
             textField.placeholder = "Password"
             textField.secureTextEntry = true
         })
         
-        alertController?.presentFrom(self.navigationController, animated: true) { () in
+        alertController.presentFrom(self.navigationController, animated: true) { () in
             // Completion handler
         }
     }

--- a/BPCompatibleAlertControllerDemo/CompatibleAlertControllerDemo/ViewController.swift
+++ b/BPCompatibleAlertControllerDemo/CompatibleAlertControllerDemo/ViewController.swift
@@ -15,20 +15,19 @@ class ViewController: UIViewController {
         
         var observerObject: NSObjectProtocol?
         
-        let cleanupAfterAlertDismissed: (Void) -> Void =
-            {
-                if (observerObject != nil)
-                {
-                    NSNotificationCenter.defaultCenter().removeObserver(observerObject!)
-                    observerObject = nil
-                }
-            }
-        
         self.view.backgroundColor = UIColor.whiteColor()
         self.title = "Demo"
         
         let alertController = BPCompatibleAlertController(title: "Alert Title", message: "Alert Message", alertStyle: BPCompatibleAlertControllerStyle.Alert)
         alertController.alertViewStyle = UIAlertViewStyle.LoginAndPasswordInput
+        
+        alertController.postActionHandlerCleanupFunction =  {
+            if (observerObject != nil)
+            {
+                NSNotificationCenter.defaultCenter().removeObserver(observerObject!)
+                observerObject = nil
+            }
+        }
         
         // Set releaseResourcesWhenAlertDismissed to false if you intend to re-use alertController to present the alert multiple times.
         // If you do so, you must remember to call alertController.releaseResources() when you are finished with the alertController.
@@ -41,19 +40,16 @@ class ViewController: UIViewController {
             if let textField = alertController.textFieldAtIndex(1) {
                 NSLog("%@", textField.text!)
             }
-            cleanupAfterAlertDismissed()
         })
         defaultAction.enabled = false
         alertController.addAction(defaultAction)
         
         alertController.addAction(BPCompatibleAlertAction.cancelActionWithTitle("Cancel", handler: { (action) in
             NSLog("Hit cancel")
-            cleanupAfterAlertDismissed()
         }))
         
         alertController.addAction(BPCompatibleAlertAction.destructiveActionWithTItle("Destructive", handler: { (action) in
             NSLog("Hit destroy")
-            cleanupAfterAlertDismissed()
         }))
         
         alertController.addTextFieldWithConfigurationHandler({ (textField) in

--- a/BPCompatibleAlertControllerDemo/CompatibleAlertControllerDemo/ViewController.swift
+++ b/BPCompatibleAlertControllerDemo/CompatibleAlertControllerDemo/ViewController.swift
@@ -12,27 +12,27 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-		
-		var observerObject: NSObjectProtocol?
-		
-		let cleanupAfterAlertDismissed: (Void) -> Void =
-			{
-				if (observerObject != nil)
-				{
-					NSNotificationCenter.defaultCenter().removeObserver(observerObject!)
-					observerObject = nil
-				}
-			}
-		
+        
+        var observerObject: NSObjectProtocol?
+        
+        let cleanupAfterAlertDismissed: (Void) -> Void =
+            {
+                if (observerObject != nil)
+                {
+                    NSNotificationCenter.defaultCenter().removeObserver(observerObject!)
+                    observerObject = nil
+                }
+            }
+        
         self.view.backgroundColor = UIColor.whiteColor()
         self.title = "Demo"
         
         let alertController = BPCompatibleAlertController(title: "Alert Title", message: "Alert Message", alertStyle: BPCompatibleAlertControllerStyle.Alert)
         alertController.alertViewStyle = UIAlertViewStyle.LoginAndPasswordInput
-		
-		// Set releaseResourcesWhenAlertDismissed to false if you intend to re-use alertController to present the alert multiple times.
-		// If you do so, you must remember to call alertController.releaseResources() when you are finished with the alertController.
-		//alertController.releaseResourcesWhenAlertDismissed = false
+        
+        // Set releaseResourcesWhenAlertDismissed to false if you intend to re-use alertController to present the alert multiple times.
+        // If you do so, you must remember to call alertController.releaseResources() when you are finished with the alertController.
+        //alertController.releaseResourcesWhenAlertDismissed = false
         
         let defaultAction = BPCompatibleAlertAction.defaultActionWithTitle("Default", handler: { (action) in
             if let textField = alertController.textFieldAtIndex(0) {
@@ -41,19 +41,19 @@ class ViewController: UIViewController {
             if let textField = alertController.textFieldAtIndex(1) {
                 NSLog("%@", textField.text!)
             }
-			cleanupAfterAlertDismissed()
+            cleanupAfterAlertDismissed()
         })
         defaultAction.enabled = false
         alertController.addAction(defaultAction)
         
         alertController.addAction(BPCompatibleAlertAction.cancelActionWithTitle("Cancel", handler: { (action) in
             NSLog("Hit cancel")
-			cleanupAfterAlertDismissed()
+            cleanupAfterAlertDismissed()
         }))
         
         alertController.addAction(BPCompatibleAlertAction.destructiveActionWithTItle("Destructive", handler: { (action) in
             NSLog("Hit destroy")
-			cleanupAfterAlertDismissed()
+            cleanupAfterAlertDismissed()
         }))
         
         alertController.addTextFieldWithConfigurationHandler({ (textField) in
@@ -61,7 +61,7 @@ class ViewController: UIViewController {
             
             // when the user types in something enable the login
             // when the user types something enable the login
-			observerObject = NSNotificationCenter.defaultCenter().addObserverForName(UITextFieldTextDidChangeNotification, object: textField, queue: NSOperationQueue.mainQueue()) { (notification) in
+            observerObject = NSNotificationCenter.defaultCenter().addObserverForName(UITextFieldTextDidChangeNotification, object: textField, queue: NSOperationQueue.mainQueue()) { (notification) in
                 defaultAction.enabled = textField.text != ""
             }
         })

--- a/README.md
+++ b/README.md
@@ -60,13 +60,3 @@ alertController = nil
 
 ##License##
 `BPCompatibleAlertController` is licensed under the MIT License. See LICENSE for details.
-
-
-```
-
-##To Do##
-1. Tests!
-2. Probably a lot more! PR's are welcome.
-
-##License##
-`BPCompatibleAlertController` is licensed under the MIT License. See LICENSE for details.

--- a/README.md
+++ b/README.md
@@ -35,14 +35,38 @@ UIAlertViewStyle.LoginAndPasswordInpnut = 2 textFields
 ###Present the alert controller:###
 ```
 alertController.presentFrom(viewController, animated: true) { () in
-  // Completion handler once everything is dismissed
+  // Completion handler once alertController has been displayed
 }
 ```
 
+###Re-presenting the alert controller:###
+By default, each instance of the alertController cleans up its internal resources automatically after the presented alert has been dismissed by the user and cannot be re-presented.
+
+If you do wish to re-use an instance, tell it to not to release its resources before presenting it, then manually `releaseResources()` when you are done.
+
+```
+alertController.releaseResourcesWhenAlertDismissed = false
+...
+alertController.presentFrom(viewController, animated: true, completion:nil)
+alertController.presentFrom(viewController, animated: true, completion:nil)
+...
+alertController.releaseResources()
+alertController = nil
+```
+
 ##To Do##
-1. You need to retain the `BPCompatibleAlertController` in iOS 7 otherwise when selecting a button from the `UIAlertView` you'll get an exception.
-2. Tests!
-3. Probably a lot more! PR's are welcome.
+1. Tests!
+2. Probably a lot more! PR's are welcome.
+
+##License##
+`BPCompatibleAlertController` is licensed under the MIT License. See LICENSE for details.
+
+
+```
+
+##To Do##
+1. Tests!
+2. Probably a lot more! PR's are welcome.
 
 ##License##
 `BPCompatibleAlertController` is licensed under the MIT License. See LICENSE for details.


### PR DESCRIPTION
(First of all, thanks very much for making BPCompatibleAlertController public!)

This pull request addresses some memory management issues.

The existing alert controller instances would never get deallocated by ARC due to internal references to 'self' (eg. NSNotificationCenter observer handler as well as any actions (blocks) that client code might pass in that happen to reference the alert controller instance.) 

These internal references did have the handy side effect(!) of preventing the iOS 7 crash alluded to in point 1 of the README's To Do section - I've now commented that explicitly in the code to help ensure it doesn't accidentally get removed.

So, the bulk of this pull request contains changes to automatically clean up resources after the alert has been dismissed. This is the default mode of operation (assuming that the alert controller instance is only used to present an alert once). If the alert controller needs to present the same alert multiple times, the client code can set a flag to prevent resource cleanup and then the onus on them to manually call the `releaseResources()` member function when they are done.

The demo code has been updated along similar lines, and the whole alert controller instance is now a local variable making it:
 a) easier to check in the debugger that ARC does indeed deallocate it after the user dismisses the dialog
 b) clear that the alert controller can be used without needing to retain a reference to it

I've also renamed the member variable `isiOS8` to `uiAlertControllerAvailable` which will then continue to make semantic sense come iOS 9.
